### PR TITLE
GitHub Actionsを用いてCI/CDパイプラインを構築し、herokuにデプロイする

### DIFF
--- a/.github/workflows/deploy_to_heroku.yml
+++ b/.github/workflows/deploy_to_heroku.yml
@@ -1,0 +1,24 @@
+name: Deploy to Heroku
+
+on:
+  workflow_run:
+    workflows:
+      - "Develop Check"
+    branches:
+      - master
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy
+        uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "stack-db-back"
+          heroku_email: "youliangdaojing5@gmail.com"
+          appdir: "stack_db_api"
+          usedocker: true

--- a/.github/workflows/develop_check.yml
+++ b/.github/workflows/develop_check.yml
@@ -1,4 +1,4 @@
-name: Test and Deploy
+name: Develop Check
 
 on:
   pull_request:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       TZ: Asia/Tokyo
       RAILS_ENV: development
-      DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
+      APP_DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - ${APP_PORT}:3000
     tty: true

--- a/stack_db_api/Dockerfile.prod
+++ b/stack_db_api/Dockerfile.prod
@@ -1,0 +1,47 @@
+# FROMでベースイメージを設定
+# 今回はRubyのバージョン3.0をベースイメージとして設定
+FROM ruby:3.0
+# nodeやyarn等の必要なライブラリをインストール
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+
+ENV APP_ROOT /var/www
+
+# Railsアプリを配置するフォルダをコンテナ内に作成
+RUN mkdir $APP_ROOT
+# 作成したディレクトリをワークディレクトリとして設定
+WORKDIR $APP_ROOT
+
+ENV BUNDLE_JOBS=4 \
+    BUNDLE_RETRY=3 \
+    BUNDLE_PATH=vendor/bundle \
+    BUNDLE_APP_CONFIG=$APP_ROOT/.bundle \
+    RAILS_ENV="production"
+
+# アプリディレクトリ配下のGemfileをコンテナ内のRailsアプリの配置場所にコピー
+COPY Gemfile ${APP_ROOT}/Gemfile
+# Gemfile.lockも同様にコンテナ内にコピーする
+COPY Gemfile.lock ${APP_ROOT}/Gemfile.lock
+# Gemfileの記述を元にbundle installを実行
+RUN bundle install
+
+# 現在のディレクトリをコンテナ内にコピー
+# これはスケルトンアプリを作成しGemfile更新後に、
+# もう一度ビルドした際にコンテナ内にGemをインストールしてアプリの雛形を作成するため
+COPY . $APP_ROOT
+
+# コンテナ起動時に実行させるスクリプトを追加
+# アクセス権限を実行可能にしておく
+# EXPOSEはドキュメント代わり。コンテナ実行時に指定したポートをコンテナがリッスンするようになる
+# EXPOSEだけではポートは公開されず、使用者からコンテナにはアクセスできない。
+# 公開用のポートとEXPOSEで指定したポートをPublishにすることで、公開されるようになる。
+# そのため、EXPOSEはイメージの作者とコンテナ実行者の両者に対して、ドキュメントのような役割をする。
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+EXPOSE 3000
+
+# Rails サーバ起動
+# entrypoint.shでexec "$@"としているためCMDで渡されるオプションが実行されることになる
+# docker-compose upはDBコンテナとまとめて起動する用の初期commandが書かれている
+# このCMDはrailsサーバーを「単独」で立ち上げて作業したい場合に用いる
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/stack_db_api/config/database.yml
+++ b/stack_db_api/config/database.yml
@@ -21,7 +21,7 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: postgres
-  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
+  password: <%= ENV.fetch("APP_DATABASE_PASSWORD") %>
   host: db
 
 development:
@@ -83,7 +83,7 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  <<: *default
-  database: www_production
-  username: www
-  password: <%= ENV['WWW_DATABASE_PASSWORD'] %>
+  database: <%= ENV['APP_DATABASE'] %>
+  username: <%= ENV['APP_DATABASE_USERNAME'] %>
+  password: <%= ENV['APP_DATABASE_PASSWORD'] %>
+  host: <%= ENV['APP_DATABASE_HOST'] %>

--- a/stack_db_api/config/environments/development.rb
+++ b/stack_db_api/config/environments/development.rb
@@ -71,4 +71,5 @@ Rails.application.configure do
     Bullet.rails_logger = true
   end
 
+  config.hosts << "https://stack-db-back.herokuapp.com/"
 end

--- a/stack_db_api/config/routes.rb
+++ b/stack_db_api/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  root  'rails/welcome#index'
 end


### PR DESCRIPTION
## Issue

#3 

## 変更の概要

GitHub Actionsを用いてworkflowを作成し、プルリクエスト作成時とmasterブランチにマージ時に自動テストと自動デプロイを行う

## なぜこの変更をするのか
前提として
- CI(継続的インテグレーション)
変更されたソースコードがGitHubなどのリポジトリに提出(プッシュ)されるたびに自動でテストを行うことで、変更後のソースコードをリポジトリのメインライン(mainブランチなど)に統合(gitで言うところのマージ)可能な状態にする仕組み
- CD(継続的デリバリー)
メインラインのソースコードを自動で本番環境などにデプロイする仕組み
を指す。

このCI/CDパイプラインをあらかじめ構築しておくことで、バグの発生を抑えつつ、アプリケーションの機能追加などを1日に何回も本番環境にリリースすることが可能になる。

そしてこのような仕組みを整えておくことで、サービスの「可用性」「性能・拡張性」「運用・保守性」が上昇するため