### PR TITLE
✨ 記事いいね・ストック機能の実装

### DIFF
--- a/stack_db_api/app/controllers/api/v1/articles_controller.rb
+++ b/stack_db_api/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticlesController < Api::V1::BaseController
-  skip_before_action :authenticate
+  skip_before_action :authenticate, only: %w[index rising]
 
   def index
     if params[:tab] == "popular"
@@ -14,6 +14,23 @@ class Api::V1::ArticlesController < Api::V1::BaseController
   def rising
     qiita_articles = QiitaArticle.where("stock > ?", 100).recent.limit(10)
     json_string = QiitaArticleSerializer.new(qiita_articles, options).serializable_hash.to_json
+    render json: json_string
+  end
+
+  def bookmarks
+    json_string = QiitaArticleSerializer.new(current_user.bookmark_qiita_articles, options).serializable_hash.to_json
+    render json: json_string
+  end
+
+  def likes
+    json_string = QiitaArticleSerializer.new(current_user.like_qiita_articles, options).serializable_hash.to_json
+    render json: json_string
+  end
+
+  def bookmark_likes
+    qiita_bookmark_or_like_articles = current_user.bookmark_qiita_articles | current_user.like_qiita_articles
+    qiita_bookmark_like_articles = QiitaArticle.where(id: qiita_bookmark_or_like_articles.map(&:id))
+    json_string = QiitaArticleSerializer.new(qiita_bookmark_like_articles, options).serializable_hash.to_json
     render json: json_string
   end
 

--- a/stack_db_api/app/controllers/api/v1/bookmarks_controller.rb
+++ b/stack_db_api/app/controllers/api/v1/bookmarks_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::BookmarksController < Api::V1::BaseController
+  def create
+    qiita_article = QiitaArticle.find(params[:qiita_article_id])
+    current_user.bookmark(qiita_article)
+    render json: {status: :ok, message: "Bookmark successfuly created!"}
+  end
+
+  def destroy
+    qiita_article = QiitaArticle.find(params[:id])
+    current_user.unbookmark(qiita_article)
+    render json: { status: :ok }
+  end
+end

--- a/stack_db_api/app/controllers/api/v1/qiita_article_likes_controller.rb
+++ b/stack_db_api/app/controllers/api/v1/qiita_article_likes_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::QiitaArticleLikesController < Api::V1::BaseController
+  def create
+    qiita_article = QiitaArticle.find(params[:qiita_article_id])
+    current_user.like(qiita_article)
+    render json: {status: :ok, message: "like successfuly created!"}
+  end
+
+  def destroy
+    qiita_article = QiitaArticle.find(params[:id])
+    current_user.unlike(qiita_article)
+    render json: { status: :ok }
+  end
+end

--- a/stack_db_api/app/models/bookmark.rb
+++ b/stack_db_api/app/models/bookmark.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: bookmarks
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  qiita_article_id :bigint           not null
+#  user_id          :bigint           not null
+#
+# Indexes
+#
+#  index_bookmarks_on_qiita_article_id              (qiita_article_id)
+#  index_bookmarks_on_user_id                       (user_id)
+#  index_bookmarks_on_user_id_and_qiita_article_id  (user_id,qiita_article_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (qiita_article_id => qiita_articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Bookmark < ApplicationRecord
+  belongs_to :qiita_article
+  belongs_to :user
+
+  validates :qiita_article_id, uniqueness: { scope: :user_id }
+end

--- a/stack_db_api/app/models/qiita_article.rb
+++ b/stack_db_api/app/models/qiita_article.rb
@@ -20,6 +20,8 @@
 class QiitaArticle < ApplicationRecord
   has_many :qiita_category_maps, dependent: :destroy
   has_many :categories, through: :qiita_category_maps, dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :qiita_article_likes, dependent: :destroy
 
   scope :popular, -> { where("stock > ?", 100).order(stock: :desc) }
   scope :recent, -> { order(date: :desc) }

--- a/stack_db_api/app/models/qiita_article_like.rb
+++ b/stack_db_api/app/models/qiita_article_like.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: qiita_article_likes
+#
+#  id               :bigint           not null, primary key
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  qiita_article_id :bigint           not null
+#  user_id          :bigint           not null
+#
+# Indexes
+#
+#  index_qiita_article_likes_on_qiita_article_id              (qiita_article_id)
+#  index_qiita_article_likes_on_user_id                       (user_id)
+#  index_qiita_article_likes_on_user_id_and_qiita_article_id  (user_id,qiita_article_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (qiita_article_id => qiita_articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class QiitaArticleLike < ApplicationRecord
+  belongs_to :qiita_article
+  belongs_to :user
+
+  validates :qiita_article_id, uniqueness: { scope: :user_id }
+
+end

--- a/stack_db_api/app/models/user.rb
+++ b/stack_db_api/app/models/user.rb
@@ -17,6 +17,11 @@
 #  index_users_on_uid  (uid) UNIQUE
 #
 class User < ApplicationRecord
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmark_qiita_articles, through: :bookmarks, source: :qiita_article
+  has_many :qiita_article_likes, dependent: :destroy
+  has_many :like_qiita_articles, through: :qiita_article_likes, source: :qiita_article
+  
   validates :nickname,    presence: true, length: { maximum: 40 }
   validates :uid,         presence: true, uniqueness: true
   validates :description, length: { maximum: 160 } 
@@ -26,5 +31,22 @@ class User < ApplicationRecord
     return user if user
 
     User.create!(uid: user_info[:uid], nickname: "User_#{user_info[:uid]}")
-  end  
+  end
+
+  def bookmark(qiita_article)
+    bookmark_qiita_articles << qiita_article
+  end
+
+  def unbookmark(qiita_article)
+    bookmark_qiita_articles.destroy(qiita_article)
+  end
+
+  def like(qiita_article)
+    like_qiita_articles << qiita_article
+  end
+
+  def unlike(qiita_article)
+    like_qiita_articles.destroy(qiita_article)
+  end
+
 end

--- a/stack_db_api/config/routes.rb
+++ b/stack_db_api/config/routes.rb
@@ -4,12 +4,16 @@ Rails.application.routes.draw do
     namespace :v1 do
       # api test action
       resources :hello, only: %w[index]
+      
       resource :image, only: %w[create show]
       resource :authentication, only: %w[create]
       resource :profile, only: %w[show update]
       resources :articles, only: %w[index] do
         collection do
           get 'rising', to: 'articles#rising'
+          get 'bookmarks', to: 'articles#bookmarks'
+          get 'likes', to: 'articles#likes'
+          get 'bookmarks_and_likes', to: 'articles#bookmark_likes'
         end
       end
       scope '/:category_name' do
@@ -21,6 +25,8 @@ Rails.application.routes.draw do
         end
       end
       get 'categories/:category_name', to: 'categories#show'
+      resources :bookmarks, only: %w[create destroy]
+      resources :qiita_article_likes, only: %w[create destroy]
     end
   end  
 end

--- a/stack_db_api/db/migrate/20230105051133_create_bookmarks.rb
+++ b/stack_db_api/db/migrate/20230105051133_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :bookmarks do |t|
+      t.references :qiita_article, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :bookmarks, [:user_id, :qiita_article_id], unique: true
+  end
+end

--- a/stack_db_api/db/migrate/20230105091527_create_qiita_article_likes.rb
+++ b/stack_db_api/db/migrate/20230105091527_create_qiita_article_likes.rb
@@ -1,0 +1,12 @@
+class CreateQiitaArticleLikes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :qiita_article_likes do |t|
+      t.references :qiita_article, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :qiita_article_likes, [:user_id, :qiita_article_id], unique: true
+
+  end
+end

--- a/stack_db_api/db/schema.rb
+++ b/stack_db_api/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_02_064757) do
+ActiveRecord::Schema.define(version: 2023_01_05_091527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "qiita_article_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["qiita_article_id"], name: "index_bookmarks_on_qiita_article_id"
+    t.index ["user_id", "qiita_article_id"], name: "index_bookmarks_on_user_id_and_qiita_article_id", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
@@ -23,6 +33,16 @@ ActiveRecord::Schema.define(version: 2023_01_02_064757) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_categories_on_name", unique: true
     t.index ["path"], name: "index_categories_on_path", unique: true
+  end
+
+  create_table "qiita_article_likes", force: :cascade do |t|
+    t.bigint "qiita_article_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["qiita_article_id"], name: "index_qiita_article_likes_on_qiita_article_id"
+    t.index ["user_id", "qiita_article_id"], name: "index_qiita_article_likes_on_user_id_and_qiita_article_id", unique: true
+    t.index ["user_id"], name: "index_qiita_article_likes_on_user_id"
   end
 
   create_table "qiita_articles", force: :cascade do |t|
@@ -59,6 +79,10 @@ ActiveRecord::Schema.define(version: 2023_01_02_064757) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "bookmarks", "qiita_articles"
+  add_foreign_key "bookmarks", "users"
+  add_foreign_key "qiita_article_likes", "qiita_articles"
+  add_foreign_key "qiita_article_likes", "users"
   add_foreign_key "qiita_category_maps", "categories"
   add_foreign_key "qiita_category_maps", "qiita_articles"
 end


### PR DESCRIPTION
## Issue

#28 

## 変更の概要

記事いいねとストック機能を実装。

## なぜこの変更をするのか

ログインユーザーがお気に入りの記事に対して共感を示せるようにするため/お気に入りの記事をストックできるようにするため
